### PR TITLE
Fix a bug when measuring 1-Qbit result

### DIFF
--- a/DJ/DJQS/Program.qs
+++ b/DJ/DJQS/Program.qs
@@ -55,11 +55,18 @@
             ApplyToEach(H,qubits);          
 
             mutable result = Zero;   
-            // Hardcoded logic to cater only for 2-qubit oracle       
-            if  bits == 2 {    
-                ApplyToEach(X, [qubits[0], qubits[1]]);
-                CCNOT(qubits[0], qubits[1], qubits[2]);               
+
+            // Hardcoded logic for 1-qubit oracles
+            if (bits == 1){
+                set result = M(qubits[0]);
             }
+        
+            // Hardcoded logicfor 2-qubit oracles     
+            if  bits == 2 {       
+                ApplyToEach(X, [qubits[0], qubits[1]]);
+                CCNOT(qubits[0], qubits[1], qubits[2]);  
+                set result = M(qubits[bits]);
+            }      
 
             set result = M(qubits[bits]);
 
@@ -73,7 +80,9 @@
     //These 2 are universal oracles. It can be used
     // by any n-qubit oracles
     operation Const0(qubits: Qubit[]) : Unit {
-        // do nothing
+        // This is universal and can be used by any
+        // n-qubit oracle. It's equal to doing nothing.
+        ApplyToEach(I, qubits); 
     }
 
 	operation Const1(qubits: Qubit[]) : Unit {      

--- a/notebooks/qdk/deutsch-jozsa.ipynb
+++ b/notebooks/qdk/deutsch-jozsa.ipynb
@@ -26,8 +26,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 1-Qubit Oracles\n",
-    "Oracles are the functions which property we want to determine. Note the use of [ancilla](https://en.wikipedia.org/wiki/Ancilla_bit) qubit to respresent the result. This is a requirement in [reversible computing](https://en.wikipedia.org/wiki/Reversible_computing) like QC."
+    "## Universal Oracles\n",
+    "Constant oracles are universal. They can be used by any n-qubit oracle."
    ]
   },
   {
@@ -44,9 +44,24 @@
     "\n",
     "operation Const1(qubits: Qubit[]) : Unit {       \n",
     "    let indexOfAncilla = Length(qubits)-1;\n",
-    "    X(qubits[indexOfAncilla]);      \n",
-    "}\n",
-    "\n",
+    "    X(qubits[indexOfAncilla]);   \n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1-Qubit Oracles\n",
+    "Oracles are the functions which property we want to determine. Note the use of [ancilla](https://en.wikipedia.org/wiki/Ancilla_bit) qubit to respresent the result. This is a requirement in [reversible computing](https://en.wikipedia.org/wiki/Reversible_computing) like QC."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "operation Balanced0(qubits: Qubit[]) : Unit {\n",
     "    CNOT(qubits[0], qubits[1]);\n",
     "}\n",
@@ -115,24 +130,29 @@
    "outputs": [],
    "source": [
     "operation DeutschJozsa(bits: Int, oracle: ((Qubit[]) => Unit)) : Result {\n",
-    "    use qubits = Qubit[bits + 1] {\n",
+    "    use qubits = Qubit[bits + 1] { // to accomodate ancilla\n",
     "\n",
     "        X(qubits[bits]);\n",
     "\n",
     "        ApplyToEach(H,qubits);\n",
     "\n",
-    "        oracle(qubits);\n",
-    "\n",
-    "        ApplyToEach(H,qubits);            \n",
+    "        oracle(qubits);     \n",
+    "        \n",
+    "        ApplyToEach(H,qubits);\n",
     "\n",
     "        mutable result = Zero;   \n",
-    "        // Hardcoded logic to cater only for 2-qubit oracle      \n",
+    "        \n",
+    "        // Hardcoded logic for 1-qubit oracles\n",
+    "        if (bits == 1){\n",
+    "            set result = M(qubits[0]);\n",
+    "        }\n",
+    "        \n",
+    "        // Hardcoded logicfor 2-qubit oracles     \n",
     "        if  bits == 2 {       \n",
     "            ApplyToEach(X, [qubits[0], qubits[1]]);\n",
-    "            CCNOT(qubits[0], qubits[1], qubits[2]);               \n",
-    "        }\n",
-    "\n",
-    "        set result = M(qubits[bits]);\n",
+    "            CCNOT(qubits[0], qubits[1], qubits[2]);  \n",
+    "            set result = M(qubits[bits]);\n",
+    "        }      \n",
     "\n",
     "        ResetAll(qubits);\n",
     "\n",
@@ -181,23 +201,22 @@
     "        // 2-qubit oracles      \n",
     "        // CAUTION! This causes error in IonQ when submitting all items. \n",
     "        // From tests, the max number of items accepted is 3. BUG?\n",
-    "        let oracles2Qubit = [\n",
-    "                            //Const0\n",
-    "                            //, Const1\n",
-    "                              Balanced_2Qubit0\n",
-    "                            , Balanced_2Qubit1\n",
-    "                            , Balanced_2Qubit2];\n",
-    "                        //, Balanced_2Qubit3\n",
-    "                        //, Balanced_2Qubit4\n",
-    "                        //, Balanced_2Qubit5];\n",
+    "        let oracles2Qubit = [Const0\n",
+    "                            ,Const1\n",
+    "                            //,Balanced_2Qubit0\n",
+    "                            //,Balanced_2Qubit1\n",
+    "                            //,Balanced_2Qubit2\n",
+    "                            //,Balanced_2Qubit3\n",
+    "                            //,Balanced_2Qubit4\n",
+    "                            ,Balanced_2Qubit5];\n",
     "\n",
     "        // 1-qubit params\n",
-    "        //let oracles = oracles1Qubit;\n",
-    "        //let qbitCount = 1;\n",
+    "        let oracles = oracles1Qubit;\n",
+    "        let qbitCount = 1;\n",
     "\n",
     "        // 2-Qubit params\n",
-    "        let oracles = oracles2Qubit;\n",
-    "        let qbitCount = 2;\n",
+    "        //let oracles = oracles2Qubit;\n",
+    "        //let qbitCount = 2;\n",
     "\n",
     "        mutable results = ConstantArray(Length(oracles),Zero);\n",
     "        \n",
@@ -251,7 +270,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%azure.submit DJMain jobName=\"DJ 3 Qubits, 3 const oracles\" shots=\"1024\""
+    "%azure.submit DJMain jobName=\"DJ 2 Qubit, 2 Const, 1 Bal (last oracle) oracles\" shots=\"1024\""
    ]
   },
   {
@@ -271,13 +290,6 @@
    "source": [
     "%azure.output \"job id here - do this only when the job is done\""
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
The DJ algorithm was made generic but the measurement for the 1qbit should still be on the data qubit instead  of ancilla for n>1.